### PR TITLE
Add crypto dashboard placeholder charts

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,24 +3,103 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>My Blank Page</title>
+  <title>Crypto Dashboard</title>
   <style>
     body {
       margin: 0;
-      padding: 0;
-      font-family: sans-serif;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 100vh;
+      padding: 20px;
+      font-family: Arial, sans-serif;
       background-color: #f0f0f0;
     }
-    h1 {
-      color: #888;
+    .coin {
+      background: #fff;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    canvas {
+      width: 100%;
+      height: 200px;
+      max-width: 600px;
+      display: block;
+      margin: 0 auto;
+    }
+    h2 {
+      text-align: center;
+    }
+    p {
+      text-align: center;
+      font-weight: bold;
     }
   </style>
 </head>
 <body>
-  <h1>This is a blank page 👋🏻</h1>
+  <div id="container"></div>
+  <script>
+    const coins = [
+      { name: 'Bitcoin', symbol: 'BTC' },
+      { name: 'Ethereum', symbol: 'ETH' },
+      { name: 'XRP', symbol: 'XRP' },
+      { name: 'Loaded Lions', symbol: 'LOADED' }
+    ];
+
+    function randomData(points, start) {
+      const data = [];
+      let value = start;
+      for (let i = 0; i < points; i++) {
+        value += (Math.random() - 0.5) * 2; // small random walk
+        data.push(value);
+      }
+      return data;
+    }
+
+    function drawChart(canvas, data) {
+      const ctx = canvas.getContext('2d');
+      const width = canvas.width;
+      const height = canvas.height;
+      ctx.clearRect(0, 0, width, height);
+      ctx.beginPath();
+      ctx.moveTo(0, height - data[0] * 2);
+      for (let i = 1; i < data.length; i++) {
+        const x = (i / (data.length - 1)) * width;
+        const y = height - data[i] * 2; // scale factor
+        ctx.lineTo(x, y);
+      }
+      ctx.strokeStyle = '#007bff';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    }
+
+    function createCoinSection(coin) {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'coin';
+      const title = document.createElement('h2');
+      title.textContent = coin.name;
+      wrapper.appendChild(title);
+
+      const canvas = document.createElement('canvas');
+      canvas.width = 600;
+      canvas.height = 200;
+      wrapper.appendChild(canvas);
+
+      const data = randomData(24, 50 + Math.random() * 20); // mock 24h prices
+      drawChart(canvas, data);
+
+      const lastPrice = data[data.length - 1];
+      const prediction = lastPrice + (Math.random() - 0.5) * 2;
+      const p = document.createElement('p');
+      p.textContent = `Predicted price after 1 hour: $${prediction.toFixed(2)}`;
+      wrapper.appendChild(p);
+
+      return wrapper;
+    }
+
+    const container = document.getElementById('container');
+    coins.forEach(coin => {
+      const section = createCoinSection(coin);
+      container.appendChild(section);
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace blank page with simple dashboard
- show Bitcoin, Ethereum, XRP and Loaded Lions sections with mock charts
- generate fake data and basic 1 hour prediction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887ef346abc83269a8b5227d54891ab